### PR TITLE
Live activity enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,36 @@ The system implements end-to-end encryption for push notifications across iOS an
 - Handles key rotation and device token management
 - Provides consistent cross-platform behavior
 - Includes error handling and logging
+## Live Activity Enrichment (iOS)
+
+An ActivityKit push-to-start notification wakes the app in the background "to
+download assets that the Live Activity needs" (Apple). During that wake,
+`LiveActivityEnricher` (started by `LiveActivityEnrichmentAppDelegateSubscriber`
+on every launch, with no JS dependency) enriches push-started Live Activities
+with E2E-encrypted PII entirely natively:
+
+1. Observes `Activity<LiveActivityAttributes>.activities` + `.activityUpdates`.
+   The attributes struct is a shape-identical duplicate of expo-widgets'
+   internal one — ActivityKit matches activities by unqualified type name, the
+   same string the push payload carries in `attributes-type`.
+2. Reads the content-state `props` JSON and extracts `encrypted_data` — a
+   `MobileNotifications::PayloadEncryptor` blob
+   `{encrypted_key, cipher_text, nonce, tag}` (object or JSON string),
+   encrypted against this device's registered public key.
+3. Decrypts via `CryptoUtils.hybridDecrypt` into a JSON object of PII fields,
+   e.g. `{"candidateName": "...", "avatarUrl": "https://..."}`.
+4. Downloads `avatarUrl` into `<app group>/ExpoWidgets/la-avatar-<key>` (the
+   directory expo-widgets shares with the widget extension) and rewrites the
+   field to the local `file://` URL. `<key>` = `props.meetingEventId`.
+5. Stages the enrichment in app-group `UserDefaults` under
+   `__tt_la_enrichment_<key>` — the widget extension merges it into props at
+   render time, so a later APNs channel update that replaces the content-state
+   cannot permanently wipe the enrichment (those updates don't wake the app).
+6. Updates the activity with the enriched props merged in (preserving
+   `staleDate`/`relevanceScore`) to re-render immediately.
+
+The decryption key is `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`: a
+wake between reboot and first unlock leaves the activity un-enriched (the
+widget falls back to its non-PII layout) and the next launch retries.
+
+Debug: `log collect --device`, subsystem = app bundle id, category `LA-enrich`.

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -2,7 +2,8 @@
   "name": "ttmobile-notification-service",
   "platforms": ["ios", "android"],
   "ios": {
-    "modules": ["EncryptionModule"]
+    "modules": ["EncryptionModule"],
+    "appDelegateSubscribers": ["LiveActivityEnrichmentAppDelegateSubscriber"]
   },
   "android": {
     "modules": ["com.teamtailor.modules.encryption.EncryptionModule"]

--- a/ios/EncryptionModule.podspec
+++ b/ios/EncryptionModule.podspec
@@ -16,6 +16,10 @@ Pod::Spec.new do |s|
   # the notification-service extension target. The LiveActivityEnrichment files
   # are main-app only: they run during the background wake an ActivityKit
   # push-to-start grants, which happens in the app process.
+  # LiveActivityRenderEnrichment.swift is likewise excluded: the config plugin
+  # compiles it into the expo-widgets WIDGET-EXTENSION target, where the render
+  # pipeline discovers it by class name to re-apply staged enrichment that
+  # broadcast-channel pushes would otherwise wipe.
   s.source_files   = 'EncryptionModule.swift', 'CryptoUtils.swift',
                      'LiveActivityEnrichment.swift', 'LiveActivityEnrichmentAppDelegateSubscriber.swift'
   s.dependency 'ExpoModulesCore'

--- a/ios/EncryptionModule.podspec
+++ b/ios/EncryptionModule.podspec
@@ -11,7 +11,13 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platform       = :ios, '13.4'
   s.source         = { git: package['repository'], tag: "v#{s.version}" }
-  s.source_files   = 'EncryptionModule.swift', 'CryptoUtils.swift'
+  # NotificationService.swift is deliberately NOT in the pod — the config
+  # plugin compiles it (plus its own copy of CryptoUtils.swift) directly into
+  # the notification-service extension target. The LiveActivityEnrichment files
+  # are main-app only: they run during the background wake an ActivityKit
+  # push-to-start grants, which happens in the app process.
+  s.source_files   = 'EncryptionModule.swift', 'CryptoUtils.swift',
+                     'LiveActivityEnrichment.swift', 'LiveActivityEnrichmentAppDelegateSubscriber.swift'
   s.dependency 'ExpoModulesCore'
   
   # Ensure we can use keychain

--- a/ios/LiveActivityEnrichment.swift
+++ b/ios/LiveActivityEnrichment.swift
@@ -12,11 +12,12 @@ import os
 // activities across targets). ContentState must stay field-identical to
 // expo-widgets' definition: { name: String, props: String }.
 //
-// PROVEN ON DEVICE (iOS 26.5): `.activities` enumeration and `.update()` work
-// fine through this duplicate. `activityUpdates` does NOT — when two same-named
-// attributes types each iterate it in one process, only the most recently
-// registered iterator (the ExpoWidgets module's) receives events; this pod's
-// stream silently yields nothing. Hence the notification bridge below.
+// PROVEN ON DEVICE (iOS 26.5): `.activities` enumeration, `.update()` AND
+// `activityUpdates` all work through this duplicate. Caveat: if two same-named
+// attributes types ever iterate `activityUpdates` in one process, only the most
+// recently registered iterator receives events (this starved the enricher while
+// the expo-widgets patch carried its own observer — since removed; keep this
+// pod's iterator the ONLY one).
 @available(iOS 16.2, *)
 struct LiveActivityAttributes: ActivityAttributes {
   struct ContentState: Codable, Hashable {
@@ -34,13 +35,10 @@ struct LiveActivityAttributes: ActivityAttributes {
 /// 1. LAUNCH ENUMERATION — `Activity<LiveActivityAttributes>.activities` at
 ///    `didFinishLaunching`. Covers the production wake: a push-to-start
 ///    launches the terminated app and the activity already exists.
-/// 2. NOTIFICATION BRIDGE — the patched expo-widgets WidgetsModule posts
-///    `TTExpoWidgetsActivityStarted` (with activityId/name/props) from its own
-///    `activityUpdates` observer. Covers activities that start while the app is
-///    already running. This pod's own `activityUpdates` iterator is starved
-///    whenever the ExpoWidgets module's iterator is also live (same
-///    attributes-type name registered twice in one process — the later
-///    registration wins), so it is kept only as a logged fallback.
+/// 2. `activityUpdates` ITERATION — covers activities that start while the app
+///    is already running. This pod owns the process's ONLY iterator (the
+///    expo-widgets observer that used to starve it was removed from the patch
+///    2026-06-12; see the attributes-type comment above).
 ///
 /// Pipeline, per newly seen activity:
 /// 1. Parse the content-state `props` JSON and extract its `encrypted_data` field — a
@@ -68,11 +66,7 @@ struct LiveActivityAttributes: ActivityAttributes {
 public actor LiveActivityEnricher {
   public static let shared = LiveActivityEnricher()
 
-  /// Posted by the patched expo-widgets WidgetsModule for every newly observed
-  /// activity. userInfo: `activityId`, `name`, `props` (strings).
-  public static let activityStartedNotification = Notification.Name("TTExpoWidgetsActivityStarted")
-
-  // Mirrors the expo-widgets patch's wake logging: notice-level os.Logger lines
+  // Notice-level os.Logger lines
   // are persisted to the device log store, so a background/terminated wake can
   // be verified retroactively with `log collect --device`. Values are .public —
   // unified logging redacts dynamics by default. Never log decrypted values.
@@ -82,7 +76,6 @@ public actor LiveActivityEnricher {
   )
 
   private var observerTask: Task<Void, Never>?
-  private var startNotificationToken: NSObjectProtocol?
   private var enrichedActivityIds = Set<String>()
   private var contentProbeTasks: [String: Task<Void, Never>] = [:]
 
@@ -102,41 +95,18 @@ public actor LiveActivityEnricher {
 
     log.notice("starting enrichment observer (existing activities: \(Activity<LiveActivityAttributes>.activities.count, privacy: .public))")
 
-    // The subscriber attaches this BEFORE the ExpoWidgets module exists (JS
-    // hasn't loaded at didFinishLaunching), so no bridge post can be missed.
-    startNotificationToken = NotificationCenter.default.addObserver(
-      forName: Self.activityStartedNotification,
-      object: nil,
-      queue: nil
-    ) { note in
-      guard let id = note.userInfo?["activityId"] as? String else { return }
-      Task { await LiveActivityEnricher.shared.enrichActivity(withId: id) }
-    }
-
     observerTask = Task {
       pruneStaleEnrichment()
       for activity in Activity<LiveActivityAttributes>.activities {
         await enrich(activity)
       }
-      // Fallback only — starved while the ExpoWidgets module's iterator is
-      // live (see type comment). The logs make its behavior observable.
-      log.notice("own activityUpdates iteration starting (fallback path)")
+      log.notice("own activityUpdates iteration starting")
       for await activity in Activity<LiveActivityAttributes>.activityUpdates {
         log.notice("own activityUpdates yielded \(activity.id, privacy: .public)")
         await enrich(activity)
       }
       log.notice("own activityUpdates iteration ENDED")
     }
-  }
-
-  /// Bridge entry point: re-resolves the activity by id through `.activities`
-  /// (unaffected by the update-stream collision) and enriches it.
-  private func enrichActivity(withId id: String) async {
-    guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
-      log.error("bridged activity \(id, privacy: .public) not found via .activities lookup")
-      return
-    }
-    await enrich(activity)
   }
 
   // PROBE: app-process visibility of remote Live Activity updates. Every

--- a/ios/LiveActivityEnrichment.swift
+++ b/ios/LiveActivityEnrichment.swift
@@ -1,0 +1,414 @@
+import ActivityKit
+import Foundation
+import os
+
+// ActivityKit matches Live Activities by the UNQUALIFIED type name of the
+// ActivityAttributes struct — the same string a push-to-start payload carries in
+// its `attributes-type` field — not by Swift type identity. expo-widgets'
+// LiveActivityAttributes is internal to its pod, so this shape-identical
+// duplicate gives this pod an independent handle on the SAME activities (the
+// main app and the widget extension already rely on this name matching to share
+// activities across targets). ContentState must stay field-identical to
+// expo-widgets' definition: { name: String, props: String }.
+//
+// PROVEN ON DEVICE (iOS 26.5): `.activities` enumeration and `.update()` work
+// fine through this duplicate. `activityUpdates` does NOT — when two same-named
+// attributes types each iterate it in one process, only the most recently
+// registered iterator (the ExpoWidgets module's) receives events; this pod's
+// stream silently yields nothing. Hence the notification bridge below.
+@available(iOS 16.2, *)
+struct LiveActivityAttributes: ActivityAttributes {
+  struct ContentState: Codable, Hashable {
+    var name: String
+    var props: String
+  }
+}
+
+/// Enriches push-started Live Activities with E2E-encrypted PII entirely on the
+/// native side, during the background wake an ActivityKit push-to-start grants
+/// ("to download assets that the Live Activity needs", per Apple) — no JS, no
+/// React, no bridge.
+///
+/// How activities reach the enricher (two paths, deduped by activity id):
+/// 1. LAUNCH ENUMERATION — `Activity<LiveActivityAttributes>.activities` at
+///    `didFinishLaunching`. Covers the production wake: a push-to-start
+///    launches the terminated app and the activity already exists.
+/// 2. NOTIFICATION BRIDGE — the patched expo-widgets WidgetsModule posts
+///    `TTExpoWidgetsActivityStarted` (with activityId/name/props) from its own
+///    `activityUpdates` observer. Covers activities that start while the app is
+///    already running. This pod's own `activityUpdates` iterator is starved
+///    whenever the ExpoWidgets module's iterator is also live (same
+///    attributes-type name registered twice in one process — the later
+///    registration wins), so it is kept only as a logged fallback.
+///
+/// Pipeline, per newly seen activity:
+/// 1. Parse the content-state `props` JSON and extract its `encrypted_data` field — a
+///    `MobileNotifications::PayloadEncryptor` blob `{encrypted_key, cipher_text,
+///    nonce, tag}` (all strict base64), encrypted against this device's
+///    registered public key.
+/// 2. Decrypt with `CryptoUtils.hybridDecrypt` (same pod, same key the NSE
+///    uses) into a JSON object of PII fields, e.g. `{candidateName, avatarUrl}`.
+/// 3. Download `avatarUrl` (https) into the app-group container under
+///    `ExpoWidgets/` so the widget extension can read it.
+/// 4. Stage the enrichment in app-group UserDefaults under
+///    `__tt_la_enrichment_<meetingEventId>` — the widget extension merges it
+///    into props at render time, which keeps enrichment alive even if a later
+///    APNs channel update replaces the content-state wholesale (the app is NOT
+///    woken for those, so only a render-time merge survives a clobber).
+/// 5. Update the activity with the enriched props merged in (preserving
+///    staleDate and relevanceScore) to trigger an immediate re-render.
+///
+/// The decryption key is `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`: a
+/// wake between reboot and first unlock cannot decrypt. That's a deliberate
+/// fallback — the widget renders its non-PII state ("Meeting" eyebrow, no
+/// avatar) and a later launch retries, since failed activities are not marked
+/// as enriched.
+@available(iOS 16.2, *)
+public actor LiveActivityEnricher {
+  public static let shared = LiveActivityEnricher()
+
+  /// Posted by the patched expo-widgets WidgetsModule for every newly observed
+  /// activity. userInfo: `activityId`, `name`, `props` (strings).
+  public static let activityStartedNotification = Notification.Name("TTExpoWidgetsActivityStarted")
+
+  // Mirrors the expo-widgets patch's wake logging: notice-level os.Logger lines
+  // are persisted to the device log store, so a background/terminated wake can
+  // be verified retroactively with `log collect --device`. Values are .public —
+  // unified logging redacts dynamics by default. Never log decrypted values.
+  private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "ttmobile-notification-service",
+    category: "LA-enrich"
+  )
+
+  private var observerTask: Task<Void, Never>?
+  private var startNotificationToken: NSObjectProtocol?
+  private var enrichedActivityIds = Set<String>()
+
+  private static let stagingKeyPrefix = "__tt_la_enrichment_"
+  private static let avatarFilePrefix = "la-avatar-"
+
+  private init() {}
+
+  /// Idempotent. Called from the app-delegate subscriber on every launch —
+  /// including background launches triggered by a push-to-start notification.
+  public func start() {
+    guard observerTask == nil else { return }
+    guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+      log.notice("Live Activities disabled — enrichment observer not started")
+      return
+    }
+
+    log.notice("starting enrichment observer (existing activities: \(Activity<LiveActivityAttributes>.activities.count, privacy: .public))")
+
+    // The subscriber attaches this BEFORE the ExpoWidgets module exists (JS
+    // hasn't loaded at didFinishLaunching), so no bridge post can be missed.
+    startNotificationToken = NotificationCenter.default.addObserver(
+      forName: Self.activityStartedNotification,
+      object: nil,
+      queue: nil
+    ) { note in
+      guard let id = note.userInfo?["activityId"] as? String else { return }
+      Task { await LiveActivityEnricher.shared.enrichActivity(withId: id) }
+    }
+
+    observerTask = Task {
+      pruneStaleEnrichment()
+      for activity in Activity<LiveActivityAttributes>.activities {
+        await enrich(activity)
+      }
+      // Fallback only — starved while the ExpoWidgets module's iterator is
+      // live (see type comment). The logs make its behavior observable.
+      log.notice("own activityUpdates iteration starting (fallback path)")
+      for await activity in Activity<LiveActivityAttributes>.activityUpdates {
+        log.notice("own activityUpdates yielded \(activity.id, privacy: .public)")
+        await enrich(activity)
+      }
+      log.notice("own activityUpdates iteration ENDED")
+    }
+  }
+
+  /// Bridge entry point: re-resolves the activity by id through `.activities`
+  /// (unaffected by the update-stream collision) and enriches it.
+  private func enrichActivity(withId id: String) async {
+    guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
+      log.error("bridged activity \(id, privacy: .public) not found via .activities lookup")
+      return
+    }
+    await enrich(activity)
+  }
+
+  // MARK: - Enrichment pipeline
+
+  private func enrich(_ activity: Activity<LiveActivityAttributes>) async {
+    guard !enrichedActivityIds.contains(activity.id) else { return }
+
+    let state = activity.content.state
+    guard var props = parseJSONObject(state.props) else {
+      log.error("activity \(activity.id, privacy: .public): props is not a JSON object — skipping")
+      enrichedActivityIds.insert(activity.id)
+      return
+    }
+
+    guard let enc = extractEncryptedBlob(props) else {
+      // Not an error: app-started activities (QA tester) and pushes predating
+      // backend enrichment simply carry no `encrypted_data`.
+      log.notice("activity \(activity.id, privacy: .public): no encrypted_data in props — nothing to enrich")
+      enrichedActivityIds.insert(activity.id)
+      // TEMPORARY PROOF OF CONCEPT — REMOVE once all backend pushes carry `encrypted_data`: visibly
+      // tag the meeting title so the full native update path (duplicated
+      // attributes struct -> observer -> activity.update -> widget re-render)
+      // can be verified on device without any encrypted payload.
+      await applyProofOfConceptTitleTag(to: activity, props: props)
+      return
+    }
+
+    let plaintext: String
+    do {
+      plaintext = try CryptoUtils.hybridDecrypt(
+        encryptedKey: enc.encryptedKey,
+        cipherText: enc.cipherText,
+        nonce: enc.nonce,
+        tag: enc.tag
+      )
+    } catch {
+      // Most likely reboot-before-first-unlock (key inaccessible) or a stale
+      // public key. NOT marked enriched — a later launch retries.
+      log.error("activity \(activity.id, privacy: .public): hybridDecrypt failed: \(String(describing: error), privacy: .public)")
+      return
+    }
+
+    guard var enrichment = parseJSONObject(plaintext) else {
+      log.error("activity \(activity.id, privacy: .public): decrypted payload is not a JSON object")
+      enrichedActivityIds.insert(activity.id)
+      return
+    }
+
+    // Stable per-meeting key shared with the render-time merge in the widget
+    // extension; the activity id is process-discoverable but absent from props,
+    // so it can't key a lookup done from props alone.
+    let stagingKey = stableKey(fromProps: props) ?? activity.id
+
+    // Replace the remote avatar URL with a local app-group file the widget
+    // extension can load. On download failure the field is dropped entirely:
+    // the renderer's `uiImage` branch does a synchronous Data(contentsOf:) with
+    // whatever URL it gets, and handing it an https URL would mean sync network
+    // on the extension's render path.
+    if let remote = enrichment["avatarUrl"] as? String {
+      enrichment["avatarUrl"] = nil
+      if let localURL = await downloadAvatar(from: remote, key: stagingKey) {
+        enrichment["avatarUrl"] = localURL.absoluteString
+      }
+    }
+
+    let hasName = enrichment["candidateName"] != nil
+    let hasAvatar = enrichment["avatarUrl"] != nil
+    stageEnrichment(enrichment, forKey: stagingKey)
+
+    // Merge into the content-state too and update natively. The staged copy is
+    // what survives content-state clobbers (render-time merge); this merge
+    // makes the enrichment visible NOW, and `enrichedAt` guards against
+    // ActivityKit deduplicating an identical content-state.
+    for (key, value) in enrichment {
+      props[key] = value
+    }
+    props["enrichedAt"] = Int(Date().timeIntervalSince1970)
+
+    guard let mergedProps = serializeJSONObject(props) else {
+      log.error("activity \(activity.id, privacy: .public): failed to re-serialize enriched props")
+      return
+    }
+
+    let newState = LiveActivityAttributes.ContentState(name: state.name, props: mergedProps)
+    let content = ActivityContent(
+      state: newState,
+      staleDate: activity.content.staleDate,
+      relevanceScore: activity.content.relevanceScore
+    )
+    await activity.update(content)
+
+    enrichedActivityIds.insert(activity.id)
+    log.notice("activity \(activity.id, privacy: .public): enriched (key=\(stagingKey, privacy: .public) name=\(hasName, privacy: .public) avatar=\(hasAvatar, privacy: .public))")
+  }
+
+  // TEMPORARY PROOF OF CONCEPT — REMOVE once all backend pushes carry `encrypted_data`. Prefixes the
+  // meeting title with a lightning bolt via a fully native content-state
+  // update, preserving staleDate/relevanceScore exactly like real enrichment.
+  private func applyProofOfConceptTitleTag(
+    to activity: Activity<LiveActivityAttributes>,
+    props: [String: Any]
+  ) async {
+    var props = props
+    let title = props["meetingTitle"] as? String ?? "Meeting"
+    guard !title.hasPrefix("⚡") else { return }
+    props["meetingTitle"] = "⚡ \(title)"
+    props["enrichedAt"] = Int(Date().timeIntervalSince1970)
+
+    guard let mergedProps = serializeJSONObject(props) else {
+      log.error("PoC: failed to re-serialize props for activity \(activity.id, privacy: .public)")
+      return
+    }
+
+    let state = activity.content.state
+    let newState = LiveActivityAttributes.ContentState(name: state.name, props: mergedProps)
+    let content = ActivityContent(
+      state: newState,
+      staleDate: activity.content.staleDate,
+      relevanceScore: activity.content.relevanceScore
+    )
+    await activity.update(content)
+    log.notice("PoC: natively tagged meetingTitle for activity \(activity.id, privacy: .public)")
+  }
+
+  // MARK: - Encrypted blob extraction
+
+  private struct EncryptedBlob {
+    let encryptedKey: String
+    let cipherText: String
+    let nonce: String
+    let tag: String
+  }
+
+  /// Accepts `encrypted_data` as either a nested JSON object or a JSON-encoded string
+  /// (the NSE's `encrypted_data` ships as a string; the props embedding may
+  /// reasonably use either).
+  private func extractEncryptedBlob(_ props: [String: Any]) -> EncryptedBlob? {
+    var dict = props["encrypted_data"] as? [String: Any]
+    if dict == nil, let raw = props["encrypted_data"] as? String {
+      dict = parseJSONObject(raw)
+    }
+    guard let dict,
+          let encryptedKey = dict["encrypted_key"] as? String,
+          let cipherText = dict["cipher_text"] as? String,
+          let nonce = dict["nonce"] as? String,
+          let tag = dict["tag"] as? String else {
+      return nil
+    }
+    return EncryptedBlob(encryptedKey: encryptedKey, cipherText: cipherText, nonce: nonce, tag: tag)
+  }
+
+  private func stableKey(fromProps props: [String: Any]) -> String? {
+    guard let value = props["meetingEventId"] else { return nil }
+    if let string = value as? String { return string }
+    if let number = value as? NSNumber { return number.stringValue }
+    return nil
+  }
+
+  // MARK: - Avatar download
+
+  private func downloadAvatar(from urlString: String, key: String) async -> URL? {
+    guard let url = URL(string: urlString), let scheme = url.scheme,
+          scheme == "https" || scheme == "http" else {
+      log.error("avatar url for key \(key, privacy: .public) is not http(s) — dropping")
+      return nil
+    }
+    guard let directory = sharedImagesDirectory() else { return nil }
+
+    let destination = directory.appendingPathComponent("\(Self.avatarFilePrefix)\(key)")
+    do {
+      let started = Date()
+      let (data, response) = try await URLSession.shared.data(from: url)
+      if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+        log.error("avatar download for key \(key, privacy: .public) got HTTP \(http.statusCode, privacy: .public)")
+        return nil
+      }
+      try data.write(to: destination, options: .atomic)
+      let elapsed = Int(Date().timeIntervalSince(started) * 1000)
+      log.notice("avatar for key \(key, privacy: .public): \(data.count, privacy: .public) bytes in \(elapsed, privacy: .public)ms")
+      return destination
+    } catch {
+      log.error("avatar download for key \(key, privacy: .public) failed: \(String(describing: error), privacy: .public)")
+      return nil
+    }
+  }
+
+  /// `<app-group container>/ExpoWidgets/` — the same directory expo-widgets
+  /// exposes to JS as `widgetsDirectory` ("shared images for widgets",
+  /// readable by both the app and the widget extension).
+  private func sharedImagesDirectory() -> URL? {
+    guard let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: appGroupIdentifier
+    ) else {
+      log.error("no app-group container for \(self.appGroupIdentifier, privacy: .public)")
+      return nil
+    }
+    let directory = container.appendingPathComponent("ExpoWidgets", isDirectory: true)
+    do {
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    } catch {
+      log.error("failed to create shared images directory: \(String(describing: error), privacy: .public)")
+      return nil
+    }
+    return directory
+  }
+
+  /// The same Info.plist key WidgetsStorage reads (written by the expo-widgets
+  /// config plugin from app.config's `groupIdentifier`), so the staging store
+  /// and the widget extension's reader can never drift apart. The fallback is
+  /// the group CryptoUtils already hardcodes for the keychain.
+  private var appGroupIdentifier: String {
+    (Bundle.main.object(forInfoDictionaryKey: "ExpoWidgetsAppGroupIdentifier") as? String)
+      ?? "group.com.teamtailor.keys"
+  }
+
+  // MARK: - Staging (read by the widget extension's render-time merge)
+
+  private func stageEnrichment(_ enrichment: [String: Any], forKey key: String) {
+    guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else {
+      log.error("no app-group UserDefaults for \(self.appGroupIdentifier, privacy: .public)")
+      return
+    }
+    defaults.set(enrichment, forKey: Self.stagingKeyPrefix + key)
+  }
+
+  /// Drops staged entries and avatar files whose meeting no longer has a live
+  /// activity, so the app-group store doesn't grow without bound. Runs once per
+  /// observer start, before enrichment.
+  private func pruneStaleEnrichment() {
+    guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
+
+    let activeKeys = Set(
+      Activity<LiveActivityAttributes>.activities.map { activity -> String in
+        guard let props = parseJSONObject(activity.content.state.props),
+              let key = stableKey(fromProps: props) else {
+          return activity.id
+        }
+        return key
+      }
+    )
+
+    for storedKey in defaults.dictionaryRepresentation().keys
+    where storedKey.hasPrefix(Self.stagingKeyPrefix) {
+      let key = String(storedKey.dropFirst(Self.stagingKeyPrefix.count))
+      if !activeKeys.contains(key) {
+        defaults.removeObject(forKey: storedKey)
+        log.notice("pruned stale enrichment for key \(key, privacy: .public)")
+      }
+    }
+
+    guard let directory = sharedImagesDirectory(),
+          let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else {
+      return
+    }
+    for file in files where file.lastPathComponent.hasPrefix(Self.avatarFilePrefix) {
+      let key = String(file.lastPathComponent.dropFirst(Self.avatarFilePrefix.count))
+      if !activeKeys.contains(key) {
+        try? FileManager.default.removeItem(at: file)
+      }
+    }
+  }
+
+  // MARK: - JSON helpers
+
+  private func parseJSONObject(_ string: String) -> [String: Any]? {
+    guard let data = string.data(using: .utf8) else { return nil }
+    return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+  }
+
+  private func serializeJSONObject(_ object: [String: Any]) -> String? {
+    guard JSONSerialization.isValidJSONObject(object),
+          let data = try? JSONSerialization.data(withJSONObject: object) else {
+      return nil
+    }
+    return String(data: data, encoding: .utf8)
+  }
+}

--- a/ios/LiveActivityEnrichment.swift
+++ b/ios/LiveActivityEnrichment.swift
@@ -84,6 +84,7 @@ public actor LiveActivityEnricher {
   private var observerTask: Task<Void, Never>?
   private var startNotificationToken: NSObjectProtocol?
   private var enrichedActivityIds = Set<String>()
+  private var contentProbeTasks: [String: Task<Void, Never>] = [:]
 
   private static let stagingKeyPrefix = "__tt_la_enrichment_"
   private static let avatarFilePrefix = "la-avatar-"
@@ -138,9 +139,30 @@ public actor LiveActivityEnricher {
     await enrich(activity)
   }
 
+  // PROBE: app-process visibility of remote Live Activity updates. Every
+  // content-state change this process observes logs a persisted line. The
+  // experiment for "does a channel broadcast wake the app?": force-quit the
+  // app, send a broadcast, watch the card re-render — then `log collect
+  // --device` and compare categories. An `LA-render` line (widget process,
+  // LiveActivityRenderEnrichment) WITHOUT a matching `LA-enrich` "saw content
+  // update" line at that timestamp is empirical proof the update rendered
+  // without waking the app. While the app IS alive, lines here also show
+  // local update() calls — match timestamps when reading the log.
+  private func probeContentUpdates(_ activity: Activity<LiveActivityAttributes>) {
+    guard contentProbeTasks[activity.id] == nil else { return }
+
+    contentProbeTasks[activity.id] = Task { [log] in
+      for await content in activity.contentUpdates {
+        log.notice("app-process saw content update for \(activity.id, privacy: .public) (staleDate: \(content.staleDate.map { "\($0)" } ?? "nil", privacy: .public))")
+      }
+      log.notice("app-process content updates ENDED for \(activity.id, privacy: .public)")
+    }
+  }
+
   // MARK: - Enrichment pipeline
 
   private func enrich(_ activity: Activity<LiveActivityAttributes>) async {
+    probeContentUpdates(activity)
     guard !enrichedActivityIds.contains(activity.id) else { return }
 
     let state = activity.content.state

--- a/ios/LiveActivityEnrichment.swift
+++ b/ios/LiveActivityEnrichment.swift
@@ -184,15 +184,18 @@ public actor LiveActivityEnricher {
     // so it can't key a lookup done from props alone.
     let stagingKey = stableKey(fromProps: props) ?? activity.id
 
-    // Replace the remote avatar URL with a local app-group file the widget
-    // extension can load. On download failure the field is dropped entirely:
-    // the renderer's `uiImage` branch does a synchronous Data(contentsOf:) with
-    // whatever URL it gets, and handing it an https URL would mean sync network
-    // on the extension's render path.
-    if let remote = enrichment["avatarUrl"] as? String {
-      enrichment["avatarUrl"] = nil
-      if let localURL = await downloadAvatar(from: remote, key: stagingKey) {
-        enrichment["avatarUrl"] = localURL.absoluteString
+    // Replace the remote avatar URLs with local app-group files the widget
+    // extension can load (first candidate + the stacked second one for group
+    // meetings). On download failure the field is dropped entirely: the
+    // renderer's `uiImage` branch does a synchronous Data(contentsOf:) with
+    // whatever URL it gets, and handing it an https URL would mean sync
+    // network on the extension's render path.
+    for (field, fileSuffix) in [("avatarUrl", ""), ("secondAvatarUrl", "-2")] {
+      if let remote = enrichment[field] as? String {
+        enrichment[field] = nil
+        if let localURL = await downloadAvatar(from: remote, key: stagingKey + fileSuffix) {
+          enrichment[field] = localURL.absoluteString
+        }
       }
     }
 
@@ -380,7 +383,11 @@ public actor LiveActivityEnricher {
       return
     }
     for file in files where file.lastPathComponent.hasPrefix(Self.avatarFilePrefix) {
-      let key = String(file.lastPathComponent.dropFirst(Self.avatarFilePrefix.count))
+      var key = String(file.lastPathComponent.dropFirst(Self.avatarFilePrefix.count))
+      // Second-candidate avatars are stored as la-avatar-<key>-2.
+      if key.hasSuffix("-2") {
+        key = String(key.dropLast(2))
+      }
       if !activeKeys.contains(key) {
         try? FileManager.default.removeItem(at: file)
       }

--- a/ios/LiveActivityEnrichment.swift
+++ b/ios/LiveActivityEnrichment.swift
@@ -155,11 +155,6 @@ public actor LiveActivityEnricher {
       // backend enrichment simply carry no `encrypted_data`.
       log.notice("activity \(activity.id, privacy: .public): no encrypted_data in props — nothing to enrich")
       enrichedActivityIds.insert(activity.id)
-      // TEMPORARY PROOF OF CONCEPT — REMOVE once all backend pushes carry `encrypted_data`: visibly
-      // tag the meeting title so the full native update path (duplicated
-      // attributes struct -> observer -> activity.update -> widget re-render)
-      // can be verified on device without any encrypted payload.
-      await applyProofOfConceptTitleTag(to: activity, props: props)
       return
     }
 
@@ -229,35 +224,6 @@ public actor LiveActivityEnricher {
 
     enrichedActivityIds.insert(activity.id)
     log.notice("activity \(activity.id, privacy: .public): enriched (key=\(stagingKey, privacy: .public) name=\(hasName, privacy: .public) avatar=\(hasAvatar, privacy: .public))")
-  }
-
-  // TEMPORARY PROOF OF CONCEPT — REMOVE once all backend pushes carry `encrypted_data`. Prefixes the
-  // meeting title with a lightning bolt via a fully native content-state
-  // update, preserving staleDate/relevanceScore exactly like real enrichment.
-  private func applyProofOfConceptTitleTag(
-    to activity: Activity<LiveActivityAttributes>,
-    props: [String: Any]
-  ) async {
-    var props = props
-    let title = props["meetingTitle"] as? String ?? "Meeting"
-    guard !title.hasPrefix("⚡") else { return }
-    props["meetingTitle"] = "⚡ \(title)"
-    props["enrichedAt"] = Int(Date().timeIntervalSince1970)
-
-    guard let mergedProps = serializeJSONObject(props) else {
-      log.error("PoC: failed to re-serialize props for activity \(activity.id, privacy: .public)")
-      return
-    }
-
-    let state = activity.content.state
-    let newState = LiveActivityAttributes.ContentState(name: state.name, props: mergedProps)
-    let content = ActivityContent(
-      state: newState,
-      staleDate: activity.content.staleDate,
-      relevanceScore: activity.content.relevanceScore
-    )
-    await activity.update(content)
-    log.notice("PoC: natively tagged meetingTitle for activity \(activity.id, privacy: .public)")
   }
 
   // MARK: - Encrypted blob extraction

--- a/ios/LiveActivityEnrichment.swift
+++ b/ios/LiveActivityEnrichment.swift
@@ -1,5 +1,6 @@
 import ActivityKit
 import Foundation
+import UIKit
 import os
 
 // ActivityKit matches Live Activities by the UNQUALIFIED type name of the
@@ -311,14 +312,37 @@ public actor LiveActivityEnricher {
         log.error("avatar download for key \(key, privacy: .public) got HTTP \(http.statusCode, privacy: .public)")
         return nil
       }
-      try data.write(to: destination, options: .atomic)
+      let imageData = downscaledImageData(data, maxDimension: 512) ?? data
+      try imageData.write(to: destination, options: .atomic)
       let elapsed = Int(Date().timeIntervalSince(started) * 1000)
-      log.notice("avatar for key \(key, privacy: .public): \(data.count, privacy: .public) bytes in \(elapsed, privacy: .public)ms")
+      log.notice("avatar for key \(key, privacy: .public): \(data.count, privacy: .public) bytes downloaded, \(imageData.count, privacy: .public) bytes written in \(elapsed, privacy: .public)ms")
       return destination
     } catch {
       log.error("avatar download for key \(key, privacy: .public) failed: \(String(describing: error), privacy: .public)")
       return nil
     }
+  }
+
+  /// Widget extensions render images within a tight memory budget — a
+  /// full-resolution original decodes to tens of MB and WidgetKit drops it
+  /// (the activity shows a gray box instead). The backend already requests a
+  /// CDN-resized variant; this is the device-side guarantee for anything that
+  /// slips through (e.g. social-sourced originals). Re-encodes as JPEG when
+  /// downscaling; returns nil (caller keeps the original bytes) when the image
+  /// is already small enough or can't be decoded.
+  private func downscaledImageData(_ data: Data, maxDimension: CGFloat) -> Data? {
+    guard let image = UIImage(data: data) else { return nil }
+    let largest = max(image.size.width, image.size.height)
+    guard largest > maxDimension else { return nil }
+
+    let scale = maxDimension / largest
+    let newSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let resized = UIGraphicsImageRenderer(size: newSize, format: format).image { _ in
+      image.draw(in: CGRect(origin: .zero, size: newSize))
+    }
+    return resized.jpegData(compressionQuality: 0.85)
   }
 
   /// `<app-group container>/ExpoWidgets/` — the same directory expo-widgets

--- a/ios/LiveActivityEnrichmentAppDelegateSubscriber.swift
+++ b/ios/LiveActivityEnrichmentAppDelegateSubscriber.swift
@@ -1,0 +1,18 @@
+import ExpoModulesCore
+
+/// Starts the Live Activity enrichment observer on EVERY launch — crucially
+/// including background launches triggered by an ActivityKit push-to-start
+/// notification, where no JS may ever run. An app-delegate subscriber is the
+/// earliest JS-independent native hook Expo offers (module OnCreate only runs
+/// once JS instantiates the module).
+public class LiveActivityEnrichmentAppDelegateSubscriber: ExpoAppDelegateSubscriber {
+  public func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    if #available(iOS 16.2, *) {
+      Task { await LiveActivityEnricher.shared.start() }
+    }
+    return true
+  }
+}

--- a/ios/LiveActivityRenderEnrichment.swift
+++ b/ios/LiveActivityRenderEnrichment.swift
@@ -1,0 +1,82 @@
+import Foundation
+import os
+
+// Compiled into the expo-widgets WIDGET-EXTENSION target by this package's
+// config plugin — deliberately NOT part of the EncryptionModule pod, because
+// render-time code must run in the widget process (see the podspec comment
+// for the same split on NotificationService.swift).
+//
+// expo-widgets' render pipeline looks this class up BY NAME via the ObjC
+// runtime (the `ExpoWidgetsLiveActivityPropsTransformer` hook patched into
+// its Widgets/Utils.swift) and passes every Live Activity's decoded
+// content-state props through `transform(_:)` before evaluating the layout.
+// The runtime lookup is what bridges the two separately-compiled modules —
+// there is no import path from the ExpoWidgets pod to this target.
+//
+// The transform re-applies the PII enrichment the main app staged in
+// app-group UserDefaults under `__tt_la_enrichment_<meetingEventId>` during
+// the push-to-start background wake (candidateName, meetingTitle, local
+// file:// avatar URLs, the rich widgetUrl, ...). Broadcast-channel update/end
+// pushes replace the content-state wholesale WITHOUT waking the app, so
+// without this render-time overlay the first broadcast would wipe the
+// enrichment. Staged values win: channel pushes never carry these keys, and
+// the plaintext value they do carry (the bare fallback widgetUrl) is exactly
+// what staging upgrades.
+@objc(ExpoWidgetsLiveActivityPropsTransformer)
+public final class LiveActivityRenderEnrichment: NSObject {
+  // Same Info.plist key WidgetsStorage reads; the staging side
+  // (LiveActivityEnrichment.swift) resolves the suite identically, so reads
+  // and writes always hit the same app-group store. The key prefix must match
+  // LiveActivityEnrichment.stagingKeyPrefix.
+  private static let appGroupIdentifier =
+    Bundle.main.object(forInfoDictionaryKey: "ExpoWidgetsAppGroupIdentifier") as? String
+  private static let stagingKeyPrefix = "__tt_la_enrichment_"
+
+  // PROBE: every Live Activity render in the WIDGET process logs a persisted
+  // notice line (category LA-render). Paired with the app-process probe in
+  // LiveActivityEnrichment (category LA-enrich): after a channel broadcast,
+  // an LA-render line with no matching LA-enrich "saw content update" line in
+  // `log collect --device` proves the update rendered without waking the app.
+  // Key COUNT only — never log staged values (PII).
+  private static let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "ExpoWidgetsTarget",
+    category: "LA-render"
+  )
+
+  @objc public func transform(_ props: [String: Any]) -> [String: Any] {
+    // Stamped by the backend into broadcast props only — a render logging a
+    // fresh value IS a delivered channel broadcast; "none" or a stale value is
+    // start content or a local re-render (stale-date, countdown, environment).
+    let broadcastAt = (props["broadcastAt"] as? NSNumber)?.stringValue
+      ?? (props["broadcastAt"] as? String) ?? "none"
+
+    guard
+      let meetingEventId = (props["meetingEventId"] as? String)
+        ?? (props["meetingEventId"] as? NSNumber)?.stringValue
+    else {
+      Self.log.notice("render transform: no meetingEventId in props — passthrough")
+      return props
+    }
+
+    guard
+      let appGroupIdentifier = Self.appGroupIdentifier,
+      let staged = UserDefaults(suiteName: appGroupIdentifier)?
+        .dictionary(forKey: Self.stagingKeyPrefix + meetingEventId)
+    else {
+      Self.log.notice("render transform for meetingEventId=\(meetingEventId, privacy: .public) broadcastAt=\(broadcastAt, privacy: .public): nothing staged — passthrough")
+      return props
+    }
+
+    // .debug: streamed (Console.app / idevicesyslog) but not persisted — this
+    // fires on every render of every surface. The passthrough lines above stay
+    // at .notice: an unenriched or id-less render is the anomaly worth keeping
+    // in a retroactive `log collect`.
+    Self.log.debug("render transform for meetingEventId=\(meetingEventId, privacy: .public) broadcastAt=\(broadcastAt, privacy: .public): merging \(staged.count, privacy: .public) staged keys")
+
+    var merged = props
+    for (key, value) in staged {
+      merged[key] = value
+    }
+    return merged
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttmobile-notification-service",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A notification service that adds communication notifications and also supports decrypting E2E encrypted notifications",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/plugin/build/index.js
+++ b/plugin/build/index.js
@@ -105,8 +105,71 @@ const withIosNotificationService = (config) => {
         [withNotificationServiceTarget, props],
         [withNotificationCommunicationsCapability, props],
         [withINSendMessageIntent, props],
+        withWidgetsRenderEnrichment,
     ]);
     return config;
+};
+// Compiles LiveActivityRenderEnrichment.swift into the expo-widgets
+// widget-extension target. The widget process is where Live Activity
+// content-state is decoded and rendered; expo-widgets discovers the class by
+// name (ExpoWidgetsLiveActivityPropsTransformer) at render time and lets it
+// re-apply the enrichment that broadcast-channel pushes would otherwise wipe.
+// The target is created by the expo-widgets plugin, so this package must be
+// listed AFTER expo-widgets in the app config's plugins array.
+const WIDGETS_TARGET_NAME = "ExpoWidgetsTarget";
+const RENDER_ENRICHMENT_FILENAME = "LiveActivityRenderEnrichment.swift";
+const withWidgetsRenderEnrichment = (config) => {
+    return (0, config_plugins_1.withXcodeProject)(config, (config) => {
+        const project = config.modResults;
+        const targetKey = project.findTargetKey(WIDGETS_TARGET_NAME);
+        if (!targetKey) {
+            throw new Error(`${WIDGETS_TARGET_NAME} was not found. List ttmobile-notification-service AFTER expo-widgets in the app config plugins.`);
+        }
+        const swiftPath = node_path_1.default.resolve(__dirname, "../..", "ios", RENDER_ENRICHMENT_FILENAME);
+        const fileReferences = project.pbxFileReferenceSection();
+        const alreadyAdded = Object.keys(fileReferences).some((key) => !key.endsWith("_comment") &&
+            String(fileReferences[key].path).replace(/^"|"$/g, "") === swiftPath);
+        if (alreadyAdded) {
+            return config;
+        }
+        // The target already compiles index.swift, so a Sources phase exists —
+        // append to it rather than creating a duplicate phase. Manual pbxproj
+        // surgery because node-xcode's addSourceFile needs a source group this
+        // generated target doesn't have.
+        const target = project.pbxNativeTargetSection()[targetKey];
+        const sourcesPhases = project.hash.project.objects.PBXSourcesBuildPhase || {};
+        const sourcesPhase = (target.buildPhases || [])
+            .map((phase) => sourcesPhases[phase.value])
+            .find(Boolean);
+        if (!sourcesPhase) {
+            throw new Error(`${WIDGETS_TARGET_NAME} has no Sources build phase.`);
+        }
+        const fileReferenceUuid = project.generateUuid();
+        fileReferences[fileReferenceUuid] = {
+            isa: "PBXFileReference",
+            fileEncoding: 4,
+            lastKnownFileType: "sourcecode.swift",
+            name: RENDER_ENRICHMENT_FILENAME,
+            path: `"${swiftPath}"`,
+            sourceTree: '"<group>"',
+            includeInIndex: 0,
+        };
+        fileReferences[`${fileReferenceUuid}_comment`] = RENDER_ENRICHMENT_FILENAME;
+        const buildFiles = project.pbxBuildFileSection();
+        const buildFileUuid = project.generateUuid();
+        buildFiles[buildFileUuid] = {
+            isa: "PBXBuildFile",
+            fileRef: fileReferenceUuid,
+            fileRef_comment: RENDER_ENRICHMENT_FILENAME,
+        };
+        buildFiles[`${buildFileUuid}_comment`] = `${RENDER_ENRICHMENT_FILENAME} in Sources`;
+        sourcesPhase.files = sourcesPhase.files || [];
+        sourcesPhase.files.push({
+            value: buildFileUuid,
+            comment: `${RENDER_ENRICHMENT_FILENAME} in Sources`,
+        });
+        return config;
+    });
 };
 const withAppGroupsEntitlements = (config) => {
     return (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {

--- a/plugin/build/index.js
+++ b/plugin/build/index.js
@@ -118,20 +118,35 @@ const withIosNotificationService = (config) => {
 // listed AFTER expo-widgets in the app config's plugins array.
 const WIDGETS_TARGET_NAME = "ExpoWidgetsTarget";
 const RENDER_ENRICHMENT_FILENAME = "LiveActivityRenderEnrichment.swift";
+// withBaseMod + nextMod-first (NOT plain withXcodeProject): expo's ios
+// xcodeproj mods do not run in plugin-array order — later registrations run
+// OUTERMOST/first, so a plain mod would execute before expo-widgets has
+// created the target. Deferring our work until after nextMod guarantees every
+// inner mod (including expo-widgets' target creation) has finished. Same
+// pattern as ttmobile's plugins/withMeetingActivityLogo.js.
 const withWidgetsRenderEnrichment = (config) => {
-    return (0, config_plugins_1.withXcodeProject)(config, (config) => {
-        const project = config.modResults;
-        const targetKey = project.findTargetKey(WIDGETS_TARGET_NAME);
-        if (!targetKey) {
-            throw new Error(`${WIDGETS_TARGET_NAME} was not found. List ttmobile-notification-service AFTER expo-widgets in the app config plugins.`);
-        }
-        const swiftPath = node_path_1.default.resolve(__dirname, "../..", "ios", RENDER_ENRICHMENT_FILENAME);
-        const fileReferences = project.pbxFileReferenceSection();
-        const alreadyAdded = Object.keys(fileReferences).some((key) => !key.endsWith("_comment") &&
-            String(fileReferences[key].path).replace(/^"|"$/g, "") === swiftPath);
-        if (alreadyAdded) {
-            return config;
-        }
+    return (0, config_plugins_1.withBaseMod)(config, {
+        platform: "ios",
+        mod: "xcodeproj",
+        async action({ modRequest: { nextMod, ...modRequest }, ...cfg }) {
+            const nextCfg = await nextMod({ ...cfg, modRequest });
+            addRenderEnrichmentSource(nextCfg.modResults);
+            return nextCfg;
+        },
+    });
+};
+const addRenderEnrichmentSource = (project) => {
+    const targetKey = project.findTargetKey(WIDGETS_TARGET_NAME);
+    if (!targetKey) {
+        throw new Error(`${WIDGETS_TARGET_NAME} was not found — is expo-widgets in the app config plugins?`);
+    }
+    const swiftPath = node_path_1.default.resolve(__dirname, "../..", "ios", RENDER_ENRICHMENT_FILENAME);
+    const fileReferences = project.pbxFileReferenceSection();
+    const alreadyAdded = Object.keys(fileReferences).some((key) => !key.endsWith("_comment") &&
+        String(fileReferences[key].path).replace(/^"|"$/g, "") === swiftPath);
+    if (alreadyAdded) {
+        return;
+    }
         // The target already compiles index.swift, so a Sources phase exists —
         // append to it rather than creating a duplicate phase. Manual pbxproj
         // surgery because node-xcode's addSourceFile needs a source group this
@@ -168,8 +183,6 @@ const withWidgetsRenderEnrichment = (config) => {
             value: buildFileUuid,
             comment: `${RENDER_ENRICHMENT_FILENAME} in Sources`,
         });
-        return config;
-    });
 };
 const withAppGroupsEntitlements = (config) => {
     return (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -152,9 +152,94 @@ const withIosNotificationService: ConfigPlugin = (config) => {
     [withNotificationServiceTarget, props],
     [withNotificationCommunicationsCapability, props],
     [withINSendMessageIntent, props],
+    withWidgetsRenderEnrichment,
   ]);
 
   return config;
+};
+
+// Compiles LiveActivityRenderEnrichment.swift into the expo-widgets
+// widget-extension target. The widget process is where Live Activity
+// content-state is decoded and rendered; expo-widgets discovers the class by
+// name (ExpoWidgetsLiveActivityPropsTransformer) at render time and lets it
+// re-apply the enrichment that broadcast-channel pushes would otherwise wipe.
+// The target is created by the expo-widgets plugin, so this package must be
+// listed AFTER expo-widgets in the app config's plugins array.
+const WIDGETS_TARGET_NAME = "ExpoWidgetsTarget";
+const RENDER_ENRICHMENT_FILENAME = "LiveActivityRenderEnrichment.swift";
+
+const withWidgetsRenderEnrichment: ConfigPlugin = (config) => {
+  return withXcodeProject(config, (config) => {
+    const project = config.modResults;
+    const targetKey = project.findTargetKey(WIDGETS_TARGET_NAME);
+    if (!targetKey) {
+      throw new Error(
+        `${WIDGETS_TARGET_NAME} was not found. List ttmobile-notification-service AFTER expo-widgets in the app config plugins.`
+      );
+    }
+
+    const swiftPath = path.resolve(
+      __dirname,
+      "../..",
+      "ios",
+      RENDER_ENRICHMENT_FILENAME
+    );
+
+    const fileReferences = project.pbxFileReferenceSection();
+    const alreadyAdded = Object.keys(fileReferences).some(
+      (key) =>
+        !key.endsWith("_comment") &&
+        String(fileReferences[key].path).replace(/^"|"$/g, "") === swiftPath
+    );
+    if (alreadyAdded) {
+      return config;
+    }
+
+    // The target already compiles index.swift, so a Sources phase exists —
+    // append to it rather than creating a duplicate phase. Manual pbxproj
+    // surgery because node-xcode's addSourceFile needs a source group this
+    // generated target doesn't have.
+    const target = project.pbxNativeTargetSection()[targetKey];
+    const sourcesPhases =
+      project.hash.project.objects.PBXSourcesBuildPhase || {};
+    const sourcesPhase = (target.buildPhases || [])
+      .map((phase: { value: string }) => sourcesPhases[phase.value])
+      .find(Boolean);
+    if (!sourcesPhase) {
+      throw new Error(`${WIDGETS_TARGET_NAME} has no Sources build phase.`);
+    }
+
+    const fileReferenceUuid = project.generateUuid();
+    fileReferences[fileReferenceUuid] = {
+      isa: "PBXFileReference",
+      fileEncoding: 4,
+      lastKnownFileType: "sourcecode.swift",
+      name: RENDER_ENRICHMENT_FILENAME,
+      path: `"${swiftPath}"`,
+      sourceTree: '"<group>"',
+      includeInIndex: 0,
+    };
+    fileReferences[`${fileReferenceUuid}_comment`] =
+      RENDER_ENRICHMENT_FILENAME;
+
+    const buildFiles = project.pbxBuildFileSection();
+    const buildFileUuid = project.generateUuid();
+    buildFiles[buildFileUuid] = {
+      isa: "PBXBuildFile",
+      fileRef: fileReferenceUuid,
+      fileRef_comment: RENDER_ENRICHMENT_FILENAME,
+    };
+    buildFiles[`${buildFileUuid}_comment`] =
+      `${RENDER_ENRICHMENT_FILENAME} in Sources`;
+
+    sourcesPhase.files = sourcesPhase.files || [];
+    sourcesPhase.files.push({
+      value: buildFileUuid,
+      comment: `${RENDER_ENRICHMENT_FILENAME} in Sources`,
+    });
+
+    return config;
+  });
 };
 
 const withAppGroupsEntitlements: ConfigPlugin = (config) => {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -2,6 +2,7 @@ import {
   ConfigPlugin,
   IOSConfig,
   withPlugins,
+  withBaseMod,
   withXcodeProject,
   withEntitlementsPlist,
   withInfoPlist,
@@ -168,13 +169,29 @@ const withIosNotificationService: ConfigPlugin = (config) => {
 const WIDGETS_TARGET_NAME = "ExpoWidgetsTarget";
 const RENDER_ENRICHMENT_FILENAME = "LiveActivityRenderEnrichment.swift";
 
+// withBaseMod + nextMod-first (NOT plain withXcodeProject): expo's ios
+// xcodeproj mods do not run in plugin-array order — later registrations run
+// OUTERMOST/first, so a plain mod would execute before expo-widgets has
+// created the target. Deferring our work until after nextMod guarantees every
+// inner mod (including expo-widgets' target creation) has finished. Same
+// pattern as ttmobile's plugins/withMeetingActivityLogo.js.
 const withWidgetsRenderEnrichment: ConfigPlugin = (config) => {
-  return withXcodeProject(config, (config) => {
-    const project = config.modResults;
+  return withBaseMod(config, {
+    platform: "ios",
+    mod: "xcodeproj",
+    async action({ modRequest: { nextMod, ...modRequest }, ...cfg }: any) {
+      const nextCfg = await nextMod({ ...cfg, modRequest });
+      addRenderEnrichmentSource(nextCfg.modResults);
+      return nextCfg;
+    },
+  });
+};
+
+const addRenderEnrichmentSource = (project: any) => {
     const targetKey = project.findTargetKey(WIDGETS_TARGET_NAME);
     if (!targetKey) {
       throw new Error(
-        `${WIDGETS_TARGET_NAME} was not found. List ttmobile-notification-service AFTER expo-widgets in the app config plugins.`
+        `${WIDGETS_TARGET_NAME} was not found — is expo-widgets in the app config plugins?`
       );
     }
 
@@ -192,7 +209,7 @@ const withWidgetsRenderEnrichment: ConfigPlugin = (config) => {
         String(fileReferences[key].path).replace(/^"|"$/g, "") === swiftPath
     );
     if (alreadyAdded) {
-      return config;
+      return;
     }
 
     // The target already compiles index.swift, so a Sources phase exists —
@@ -237,9 +254,6 @@ const withWidgetsRenderEnrichment: ConfigPlugin = (config) => {
       value: buildFileUuid,
       comment: `${RENDER_ENRICHMENT_FILENAME} in Sources`,
     });
-
-    return config;
-  });
 };
 
 const withAppGroupsEntitlements: ConfigPlugin = (config) => {


### PR DESCRIPTION
## Summary

This package is the Expo native module the app embeds for push handling — today it builds the iOS **Notification Service Extension** (communication-notification avatars) and the **E2E encryption** layer (RSA+AES hybrid, keys in the keychain). This PR adds a third capability: **enriching push-started meeting Live Activities with encrypted PII, entirely natively — no JS, no React, no bridge.**

The backend can only put **non-PII** in plaintext in an APNs Live Activity push (ids, timestamps, location, job title). Anything identifying a person (candidate name, avatar, the candidate-linked tap URL) ships as an encrypted blob (`encrypted_data`) inside the push. This branch decrypts that blob on-device and merges it into the activity, so the card shows real names/avatars without PII ever traveling APNs in the clear.

## Why this is awkward (and why the code is split across three targets)

A Live Activity is rendered by a separate **widget-extension process**, not the app. And APNs has two ways to update an activity, with very different consequences here:

- **push-to-start** — wakes the app in the background ("to download assets the Live Activity needs", per Apple). The app process *can* run code here.
- **broadcast-channel update/end** (iOS 18+) — replaces the activity's content-state wholesale and **does not wake the app**.

So decryption (which needs the keychain private key, available only in the app process) and rendering (which happens in the widget process) live in different places, and a later broadcast would clobber any PII we merged into the content-state. This PR solves all three:

1. **App process — `LiveActivityEnricher` (`LiveActivityEnrichment.swift`)**
   Started on *every* launch by an Expo **app-delegate subscriber** (`LiveActivityEnrichmentAppDelegateSubscriber`) — the earliest JS-independent hook, so it runs even on a background push-to-start wake where JS never boots. It observes `Activity<LiveActivityAttributes>.activities` + `.activityUpdates`, and per new activity: extracts `encrypted_data` from the content-state `props`, decrypts it via the pod's existing `CryptoUtils.hybridDecrypt`, downloads `avatarUrl` into the shared app-group container (downscaled to ≤512px, rewritten to a `file://` URL the widget can load synchronously), **stages** the result in app-group `UserDefaults` under `__tt_la_enrichment_<meetingEventId>`, and updates the activity to render immediately.

2. **Widget process — `LiveActivityRenderEnrichment.swift`**
   Compiled into the expo-widgets **widget-extension** target. expo-widgets looks it up *by class name* at render time (`ExpoWidgetsLiveActivityPropsTransformer`) and passes every activity's decoded props through `transform(_:)` before layout. It re-applies the staged enrichment on every render — so a broadcast update that wiped the content-state can't permanently remove the PII (the staged copy wins, and the app doesn't need to wake).

3. **Encryption** reuses the existing `CryptoUtils` / `PayloadEncryptor` contract (`{encrypted_key, cipher_text, nonce, tag}`), the same key the NSE uses.

## Config plugin / build wiring

- **`expo-module.config.json`** — registers the app-delegate subscriber.
- **`EncryptionModule.podspec`** — adds the two app-process Swift files to the pod; the render-enrichment file is deliberately *excluded* (it must compile into the widget extension, not the app).
- **`plugin/src/index.ts`** — new `withWidgetsRenderEnrichment` mod injects `LiveActivityRenderEnrichment.swift` into the `ExpoWidgetsTarget` via manual pbxproj surgery. It uses `withBaseMod` + nextMod-first because Expo's iOS xcodeproj mods don't run in plugin-array order — this defers our injection until *after* expo-widgets has created the target. (Consequence: this package must be listed **after** `expo-widgets` in the app config.)

## Type-matching gotcha

`LiveActivityAttributes` here is a **shape-identical duplicate** of expo-widgets' internal struct. ActivityKit matches activities by the *unqualified type name* (the `attributes-type` string the push carries), not Swift type identity — so this duplicate gives the pod an independent handle on the same activities. Caveat documented in-code: only one `activityUpdates` iterator per process receives events, so this pod must own the only one (the expo-widgets patch's own observer was removed for this reason).

## Security / fallback

- Decryption key is `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. A wake between reboot and first unlock can't decrypt → the widget falls back to its non-PII layout and the next launch retries (failed activities aren't marked enriched).
- Logging never emits decrypted values — key **counts** only. Debug via `log collect --device`, categories `LA-enrich` (app) and `LA-render` (widget).

## Dropped

The earlier "activity-started notification bridge" POC was removed in favor of the app-delegate-subscriber approach.

## Depends on / pairs with

The render-time hook this relies on is added to expo-widgets by the app-side PR (`feature/meeting-live-activity`)'s `patches/expo-widgets+*.patch`. Review them together.